### PR TITLE
Explicitly request Python 2

### DIFF
--- a/pt.py
+++ b/pt.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # coding=utf-8
 
 import argparse

--- a/pumptweet/shorturl.py
+++ b/pumptweet/shorturl.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 #   shorturl.py
 #   Shorts a long URL from command line, using ur1.ca.

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # setup.py
 
 from setuptools import setup


### PR DESCRIPTION
Some systems, notably Arch Linux, have decided that because they're
bleeding edge, they're going to have /usr/bin/python set to Python 3
instead of Python 2. Of course, this wreaks havoc with applications that
are (reasonably) expecting /usr/bin/python to be Python 2, but what can
you do?

Therefore, explicitly request python2 instead of python in the shebang
line.
