### PR TITLE
Fix moved exception

### DIFF
--- a/pumptweet/PumpLogin.py
+++ b/pumptweet/PumpLogin.py
@@ -5,7 +5,7 @@ from dateutil.parser import parse
 from configparser import ConfigParser
 from pypump import PyPump
 from pypump import Client
-from pypump.client import ClientException
+from pypump.exceptions import ClientException
 from requests.exceptions import ConnectionError
 
 def simple_verifier(url):

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(name='pumptweet',
 	license='MIT',
 	packages=['pumptweet'],
 	install_requires=[
-		'pypump >= 0.6',
+		'pypump >= 0.7',
 		'python-twitter >= 3.1',
 	],
 	include_package_data=True,


### PR DESCRIPTION
PyPump 0.7 has been released and we moved all exceptions into one module. This patch updates PumpTweet to reflect that change.

Note: I haven't actually tested anything as I don't have time to do all the setup stuff.